### PR TITLE
Update Cloning Process

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -19,11 +19,20 @@ env | sort | grep "POD\|HOST\|NAME"
 echo "running">/scripts/setup.txt
 
 # How long a joining member waits for a busy donor before giving up on it.
-# MySQL serves only one clone per donor, so members seeded at the same time
-# queue here. Seeding a large database can take many minutes, hence the
-# generous default ceiling.
+#
+# MySQL serves only one clone per donor, so members seeded at the same time queue
+# here and each one waits for however long the clones ahead of it take. That is a
+# function of the database size, the disk and the replica count — none of which
+# this script can know — so there is deliberately NO default ceiling: a wall-clock
+# limit sized for one database silently abandons the clone on a larger one, which
+# is the failure this retry exists to prevent.
+#
+# The bound belongs to the operation, not to this loop: MySQLOpsRequest
+# spec.timeout already fails the request if it takes too long. Set
+# CLONE_BUSY_MAX_WAIT to a number of seconds only if you specifically want a
+# per-donor cap; 0 (the default) waits as long as the donor stays busy.
 clone_busy_retry_interval=${CLONE_BUSY_RETRY_INTERVAL:-15}
-clone_busy_max_wait=${CLONE_BUSY_MAX_WAIT:-3600}
+clone_busy_max_wait=${CLONE_BUSY_MAX_WAIT:-0}
 
 # How often the progress of a running clone is written to the pod log.
 clone_progress_interval=${CLONE_PROGRESS_INTERVAL:-15}
@@ -674,8 +683,9 @@ function clone_from_donor() {
         fi
 
         if [[ "$error_message" == *"Too many concurrent clone operations"* ]]; then
-            if [[ $waited -ge $clone_busy_max_wait ]]; then
-                log "ERROR" "Donor $donor still busy after ${waited}s, giving up on this donor"
+            # 0 = wait indefinitely; the ops request timeout is the real bound.
+            if [[ $clone_busy_max_wait -gt 0 && $waited -ge $clone_busy_max_wait ]]; then
+                log "ERROR" "Donor $donor still busy after ${waited}s (CLONE_BUSY_MAX_WAIT), giving up on this donor"
                 return 1
             fi
             log "INFO" "Donor $donor is busy serving another clone, retrying in ${clone_busy_retry_interval}s (waited ${waited}s so far)"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -841,6 +841,26 @@ while true; do
     joining_for_first_time=0
     log "INFO" "removing setup.txt file"
     rm -rf /scripts/setup.txt
+
+    # A join that did not take must not be terminal. `wait $pid` below only
+    # returns when mysqld exits, so a healthy mysqld parks this loop forever and
+    # every later signal the coordinator writes — including the create_cluster
+    # signal that re-bootstraps the group after a full outage — is never read.
+    # Observed: all members down, the coordinator decided on a bootstrap after
+    # ~16 minutes, wrote the signal, and it sat unread while the members went on
+    # failing to *join* a group that no longer existed; recovery needed a manual
+    # bootstrap.
+    #
+    # If this member is not ONLINE in the group, re-arm and wait for the next
+    # signal instead of blocking. Mirrors the same guard in run_innodb.sh.
+    member_state=$(${mysql_header} --host=$localhost -N -e \
+        "SELECT MEMBER_STATE FROM performance_schema.replication_group_members WHERE MEMBER_HOST='${report_host}' LIMIT 1;" 2>/dev/null)
+    if [[ "$member_state" != "ONLINE" ]]; then
+        log "WARNING" "not ONLINE in the group after handling the signal (state='${member_state:-unknown}') — waiting for the coordinator to signal again"
+        sleep 10
+        continue
+    fi
+
     log "INFO" "waiting for mysql process id  = $pid"
     wait $pid
 done

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -17,6 +17,16 @@
 
 env | sort | grep "POD\|HOST\|NAME"
 echo "running">/scripts/setup.txt
+
+# How long a joining member waits for a busy donor before giving up on it.
+# MySQL serves only one clone per donor, so members seeded at the same time
+# queue here. Seeding a large database can take many minutes, hence the
+# generous default ceiling.
+clone_busy_retry_interval=${CLONE_BUSY_RETRY_INTERVAL:-15}
+clone_busy_max_wait=${CLONE_BUSY_MAX_WAIT:-3600}
+
+# How often the progress of a running clone is written to the pod log.
+clone_progress_interval=${CLONE_PROGRESS_INTERVAL:-15}
 RECOVERY_DONE_FILE="/tmp/recovery.done"
 if [[ "$PITR_RESTORE" == "true" ]]; then
     while true; do
@@ -603,10 +613,87 @@ function join_into_cluster() {
     echo "end join in cluster"
 }
 
+# log_clone_progress polls performance_schema.clone_progress and logs how far the
+# running CLONE INSTANCE has got. Seeding a large database takes many minutes
+# during which the pod looks idle, so without this there is no way to tell a
+# healthy long clone apart from a stuck one.
+#
+# CLONE INSTANCE blocks the connection that issued it, so this runs as a
+# background poller and is stopped once the clone returns.
+function log_clone_progress() {
+    local mysql="$mysql_header --host=$localhost"
+    while true; do
+        # FILE COPY is the stage that moves the data; the others are negligible.
+        progress=$(${mysql} -N -B -e "
+            SELECT CONCAT(
+                     STAGE, ' ',
+                     ROUND(100 * DATA / ESTIMATE, 1), '% (',
+                     ROUND(DATA / 1024 / 1024), ' MiB of ',
+                     ROUND(ESTIMATE / 1024 / 1024), ' MiB, ',
+                     ROUND(DATA_SPEED / 1024 / 1024), ' MiB/s)')
+              FROM performance_schema.clone_progress
+             WHERE ESTIMATE > 0 AND STATE <> 'Not Started'
+             ORDER BY ID DESC LIMIT 1;" 2>/dev/null)
+        if [[ -n "$progress" ]]; then
+            log "INFO" "Clone progress: $progress"
+        fi
+        sleep "$clone_progress_interval"
+    done
+}
+
+# clone_from_donor runs CLONE INSTANCE against a single donor and returns 0 only
+# when the clone actually succeeded.
+#
+# MySQL permits exactly ONE concurrent clone operation per donor
+# (error 3634: "Too many concurrent clone operations. Maximum allowed - 1.").
+# When several fresh members are seeded at the same time they race for the same
+# donor and every loser is rejected within milliseconds. That is a transient
+# "donor is busy" condition, not a real failure, so wait for the donor to become
+# free and try again instead of giving up.
+function clone_from_donor() {
+    local donor=$1
+    local mysql="$mysql_header --host=$localhost"
+    local waited=0
+
+    while true; do
+        log_clone_progress &
+        local progress_pid=$!
+
+        error_message=$(${mysql} -N -e "CLONE INSTANCE FROM 'repl'@'$donor':3306 IDENTIFIED BY '$MYSQL_ROOT_PASSWORD' REQUIRE SSL;" 2>&1)
+
+        kill "$progress_pid" 2>/dev/null
+        wait "$progress_pid" 2>/dev/null
+
+        # A successful clone ends with:
+        #   "ERROR 3707 (HY000): Restart server failed (mysqld is not managed by supervisor process)"
+        # which means the data was copied and mysqld must be started again manually.
+        # https://dev.mysql.com/doc/refman/8.0/en/clone-plugin-remote.html
+        log "INFO" "Clone error message: $error_message"
+        if [[ "$error_message" == *"mysqld is not managed by supervisor process"* ]]; then
+            return 0
+        fi
+
+        if [[ "$error_message" == *"Too many concurrent clone operations"* ]]; then
+            if [[ $waited -ge $clone_busy_max_wait ]]; then
+                log "ERROR" "Donor $donor still busy after ${waited}s, giving up on this donor"
+                return 1
+            fi
+            log "INFO" "Donor $donor is busy serving another clone, retrying in ${clone_busy_retry_interval}s (waited ${waited}s so far)"
+            sleep "$clone_busy_retry_interval"
+            waited=$((waited + clone_busy_retry_interval))
+            continue
+        fi
+
+        # any other error: this donor cannot serve us
+        return 1
+    done
+}
+
 function join_by_clone() {
     # member try to join into the existing group
     log "INFO" "The replica, ${report_host} is joining into the existing group..."
     local mysql="$mysql_header --host=$localhost"
+    local clone_done=0
 
     # Temporarily disable read-only for clone operations.
     # GR will manage read-only after START GROUP_REPLICATION.
@@ -621,17 +708,11 @@ function join_by_clone() {
     if [[ $valid_donor_found == 1 ]]; then
         for donor in ${donors[*]}; do
             log "INFO" "Cloning data from $donor to $report_host....."
-            error_message=$(${mysql} -N -e "CLONE INSTANCE FROM 'repl'@'$donor':3306 IDENTIFIED BY '$MYSQL_ROOT_PASSWORD' REQUIRE SSL;" 2>&1)
-            # we may get an error when the cloning process has finished like:
-            # ".ERROR 3707 (HY000) at line 1: Restart server failed (mysqld is not managed by supervisor process)"
-            # This error does not indicate a cloning failure.
-            # It means that the recipient MySQL server instance must be started again manually after the data is cloned
-            # https://dev.mysql.com/doc/refman/8.0/en/clone-plugin-remote.html#:~:text=ERROR%203707%20(HY000)%3A%20Restart,not%20managed%20by%20supervisor%20process).&text=It%20means%20that%20the%20recipient,after%20the%20data%20is%20cloned.
-            log "INFO" "Clone error message: $error_message"
-            if [[ "$error_message" != *"mysqld is not managed by supervisor process"* ]]; then
+            if ! clone_from_donor "$donor"; then
                 # retry cloning process for next valid donor
                 continue
             fi
+            clone_done=1
 
             # wait for background process `mysqld` have been killed
             for i in {60..0}; do
@@ -652,6 +733,18 @@ function join_by_clone() {
 
         done
     fi
+
+    # join_by_clone is only signalled when this member must be seeded from a donor
+    # (the donor holds data this member does not have, or this member holds
+    # transactions the group does not). If no donor could serve the clone, joining
+    # the group anyway would put an EMPTY member ONLINE, where it is indistinguishable
+    # from a healthy secondary and silently serves empty reads. Refuse to join and
+    # let the coordinator re-issue the clone instead.
+    if [[ $clone_done == 0 ]]; then
+        log "ERROR" "Clone failed from every donor; refusing to join the group with an empty dataset. The coordinator will retry."
+        return 1
+    fi
+
     # If the host is still alive, it will join the cluster directly.
     if [[ $mysqld_alive == 1 ]]; then
         retry 60 ${mysql} -N -e "START GROUP_REPLICATION;"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -841,26 +841,6 @@ while true; do
     joining_for_first_time=0
     log "INFO" "removing setup.txt file"
     rm -rf /scripts/setup.txt
-
-    # A join that did not take must not be terminal. `wait $pid` below only
-    # returns when mysqld exits, so a healthy mysqld parks this loop forever and
-    # every later signal the coordinator writes — including the create_cluster
-    # signal that re-bootstraps the group after a full outage — is never read.
-    # Observed: all members down, the coordinator decided on a bootstrap after
-    # ~16 minutes, wrote the signal, and it sat unread while the members went on
-    # failing to *join* a group that no longer existed; recovery needed a manual
-    # bootstrap.
-    #
-    # If this member is not ONLINE in the group, re-arm and wait for the next
-    # signal instead of blocking. Mirrors the same guard in run_innodb.sh.
-    member_state=$(${mysql_header} --host=$localhost -N -e \
-        "SELECT MEMBER_STATE FROM performance_schema.replication_group_members WHERE MEMBER_HOST='${report_host}' LIMIT 1;" 2>/dev/null)
-    if [[ "$member_state" != "ONLINE" ]]; then
-        log "WARNING" "not ONLINE in the group after handling the signal (state='${member_state:-unknown}') — waiting for the coordinator to signal again"
-        sleep 10
-        continue
-    fi
-
     log "INFO" "waiting for mysql process id  = $pid"
     wait $pid
 done

--- a/scripts/run_innodb.sh
+++ b/scripts/run_innodb.sh
@@ -264,6 +264,43 @@ mysql_local="mysql -u${MYSQL_ROOT_USERNAME} -hlocalhost -p${MYSQL_ROOT_PASSWORD}
 mysqlsh_local="mysqlsh --js -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}"
 replication_user=repl
 
+clone_progress_interval=${CLONE_PROGRESS_INTERVAL:-15}
+
+# dba.addInstance waits dba.restartWaitTimeout seconds for the post-clone restart.
+# Raising it does not help: the clone's self-RESTART fails immediately (MY-013462,
+# nothing supervises mysqld in the container) and Group Replication evicts the
+# member on that error before any restart wait is consulted. Left at the default.
+dba_restart_wait_timeout=${DBA_RESTART_WAIT_TIMEOUT:-60}
+
+# log_clone_progress polls performance_schema.clone_progress and logs how far the
+# running clone has got. Mirrors the GroupReplication path in run.sh: seeding a
+# large database takes many minutes during which the pod looks idle, so without
+# this a healthy long clone is indistinguishable from a stuck one.
+#
+# The clone is driven by dba.addInstance against the primary, but the data is
+# written by the joining instance — this script's own host — so the progress rows
+# are local. addInstance blocks until the clone finishes, so this runs as a
+# background poller and is stopped once the call returns.
+function log_clone_progress() {
+    while true; do
+        # FILE COPY is the stage that moves the data; the others are negligible.
+        progress=$(${mysql_local} -N -B -e "
+            SELECT CONCAT(
+                     STAGE, ' ',
+                     ROUND(100 * DATA / ESTIMATE, 1), '% (',
+                     ROUND(DATA / 1024 / 1024), ' MiB of ',
+                     ROUND(ESTIMATE / 1024 / 1024), ' MiB, ',
+                     ROUND(DATA_SPEED / 1024 / 1024), ' MiB/s)')
+              FROM performance_schema.clone_progress
+             WHERE ESTIMATE > 0 AND STATE <> 'Not Started'
+             ORDER BY ID DESC LIMIT 1;" 2>/dev/null)
+        if [[ -n "$progress" ]]; then
+            log "INFO" "Clone progress: $progress"
+        fi
+        sleep "$clone_progress_interval"
+    done
+}
+
 # Kill any stale mysqlsh AdminAPI session holding the cluster-wide EXCLUSIVE lock
 # on $1 (usually the primary). A session holding AdminAPI_lock while in Sleep
 # state means a previous mysqlsh call died without releasing — rescan/addInstance/
@@ -561,6 +598,9 @@ function join_in_cluster() {
     # this, dba.getCluster() raises "unmanaged replication group" and addInstance
     # loops forever.
     fix_metadata_uuids
+    # After a clone the instance restarts and rejoins the group on its own; it is
+    # then a member AdminAPI does not know about and addInstance would reject it.
+    leave_group_if_unmanaged
     # Temporarily disable read-only for join operations (match run.sh)
     ${mysql_local} -N -e "SET GLOBAL super_read_only=OFF; SET GLOBAL read_only=OFF;" 2>/dev/null
     clear_stale_cluster_lock "${primary}"
@@ -578,9 +618,61 @@ function join_by_clone() {
     clear_stale_cluster_lock "${primary}"
     retry 10 ${mysqlsh_primary} -e "cluster = dba.getCluster(); cluster.removeInstance('${report_host}:3306',{force:true});"
     clear_stale_cluster_lock "${primary}"
-    retry 10 ${mysqlsh_primary} -e "cluster = dba.getCluster(); cluster.addInstance('${replication_user}:${MYSQL_ROOT_PASSWORD}@${report_host}:3306',{recoveryMethod:'clone'});"
+    # Report clone progress while addInstance blocks, and give the post-clone
+    # restart room to finish instead of the 60s default.
+    log_clone_progress &
+    local progress_pid=$!
+    retry 10 ${mysqlsh_primary} -e "
+        shell.options['dba.restartWaitTimeout'] = ${dba_restart_wait_timeout};
+        cluster = dba.getCluster();
+        cluster.addInstance('${replication_user}:${MYSQL_ROOT_PASSWORD}@${report_host}:3306',{recoveryMethod:'clone'});"
+    kill "$progress_pid" 2>/dev/null
+    wait "$progress_pid" 2>/dev/null
     # Clone restarts mysqld — wait for the old process to finish
     wait $pid
+}
+
+# metadata_schema_exists is true once mysql_innodb_cluster_metadata has been
+# replicated to this instance, i.e. the group this member sits in is an
+# AdminAPI-managed InnoDB cluster rather than a plain Group Replication group.
+function metadata_schema_exists() {
+    local count
+    count=$(${mysql_local} -N -B -e "
+        SELECT COUNT(*) FROM information_schema.schemata
+         WHERE schema_name = 'mysql_innodb_cluster_metadata';" 2>/dev/null)
+    [[ "$count" =~ ^[0-9]+$ ]] && [[ "$count" -gt 0 ]]
+}
+
+# is_registered_in_metadata is true when this instance's own address is recorded
+# in the cluster metadata. A member can be ONLINE in the group and still be
+# absent here — see the signal loop for how that happens and why it is fatal.
+function is_registered_in_metadata() {
+    local count
+    count=$(${mysql_local} -N -B -e "
+        SELECT COUNT(*) FROM mysql_innodb_cluster_metadata.instances
+         WHERE address = '${report_host}:3306';" 2>/dev/null)
+    [[ "$count" =~ ^[0-9]+$ ]] && [[ "$count" -gt 0 ]]
+}
+
+# leave_group_if_unmanaged stops Group Replication when this instance is a group
+# member the cluster metadata does not know about. mysqld rejoins the group on
+# boot by itself, so after the post-clone restart the instance is back in the
+# group before AdminAPI ever recorded it — and addInstance then refuses it
+# ("already part of a Replication Group") while dba.getCluster() against it
+# fails ("unmanaged replication group"). Leaving the group first turns the
+# instance back into a plain joiner that addInstance can accept.
+function leave_group_if_unmanaged() {
+    local state
+    state=$(${mysql_local} -N -e "
+        SELECT MEMBER_STATE FROM performance_schema.replication_group_members
+         WHERE MEMBER_HOST='${report_host}' LIMIT 1;" 2>/dev/null)
+    if [[ -z "$state" || "$state" == "OFFLINE" ]]; then
+        return
+    fi
+    if metadata_schema_exists && ! is_registered_in_metadata; then
+        log "WARNING" "in the group ($state) but absent from the InnoDB Cluster metadata — leaving the group so the AdminAPI join can register it"
+        ${mysql_local} -N -e "STOP GROUP_REPLICATION;" 2>/dev/null
+    fi
 }
 
 joined_in_cluster=0
@@ -785,8 +877,26 @@ while true; do
         member_state=$(mysql -u${MYSQL_ROOT_USERNAME} -hlocalhost -p${MYSQL_ROOT_PASSWORD} -N -e \
             "SELECT MEMBER_STATE FROM performance_schema.replication_group_members WHERE MEMBER_HOST='${report_host}' LIMIT 1;" 2>/dev/null)
         if [[ "$member_state" == "ONLINE" ]]; then
-            log "INFO" "Already ONLINE in GR group (joined by another node's reboot) — skipping signal wait"
-            break
+            # Being ONLINE in the group is NOT the same as being known to the
+            # AdminAPI. cluster.addInstance(recoveryMethod:'clone') restarts the
+            # joining instance once the clone finishes, and mysqld rejoins the
+            # group by itself on boot (group_replication_start_on_boot) — often
+            # before the coordinator has written the join signal, and always
+            # before addInstance got the chance to record the instance in
+            # mysql_innodb_cluster_metadata. Breaking out here would leave a
+            # group member the cluster metadata does not contain, and from then
+            # on dba.getCluster() against this member fails with "unmanaged
+            # replication group", so no further pod can ever join.
+            #
+            # Stop GR instead and fall through to the signal-driven join, which
+            # goes through addInstance and does register the instance. The
+            # datadir is kept, so that join is incremental, not another clone.
+            if metadata_schema_exists && ! is_registered_in_metadata; then
+                leave_group_if_unmanaged
+            else
+                log "INFO" "Already ONLINE in GR group (joined by another node's reboot) — skipping signal wait"
+                break
+            fi
         fi
         log "WARNING" "signal is not present yet!"
         sleep 1
@@ -834,6 +944,20 @@ while true; do
     log "INFO" "removing setup.txt file"
     rm -rf /scripts/signal.txt
     rm -rf /scripts/setup.txt
+
+    # A join that exhausted its retries must not be terminal. The coordinator
+    # keeps re-issuing the signal, but blocking on the mysqld pid below means
+    # this loop never reads it again — the pod stays Running and out of the
+    # group until someone deletes it by hand. If we are still not a group
+    # member, re-arm and wait for the next signal instead.
+    member_state=$(${mysql_local} -N -e \
+        "SELECT MEMBER_STATE FROM performance_schema.replication_group_members WHERE MEMBER_HOST='${report_host}' LIMIT 1;" 2>/dev/null)
+    if [[ "$member_state" != "ONLINE" ]]; then
+        log "WARNING" "not ONLINE in the group after handling the signal — waiting for the coordinator to signal again"
+        sleep 10
+        continue
+    fi
+
     log "INFO" "waiting for mysql process id = $pid"
     wait $pid
 done

--- a/scripts/run_innodb.sh
+++ b/scripts/run_innodb.sh
@@ -409,6 +409,25 @@ function create_cluster() {
     fi
 }
 
+# adopt_from_gr converts the pod's currently-running Group Replication group into
+# a managed InnoDB cluster IN PLACE, without tearing the group down or cloning.
+# Used when a GroupReplication database is transformed to InnoDBCluster: the group
+# is still ONLINE, so dba.createCluster(adoptFromGR:true) adopts every member and
+# preserves all data. Must run while GR is ONLINE (do not restart mysqld first).
+function adopt_from_gr() {
+    local mysqlsh_self="mysqlsh --js -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD} -h${report_host}"
+    clusterName=$(echo -n $BASE_NAME | sed 's/-/_/g')
+    ${mysql_local} -N -e "SET GLOBAL super_read_only=OFF; SET GLOBAL read_only=OFF;" 2>/dev/null
+    local create_opts="multiPrimary:false,force:true"
+    if [[ "$PRIMARY_TYPE" == "Multi-Primary" ]]; then
+        create_opts="multiPrimary:true,force:true"
+    fi
+    log "INFO" "adopting existing GR group as an InnoDB cluster (adoptFromGR:true)"
+    retry 5 $mysqlsh_self -e "dba.createCluster('$clusterName',{adoptFromGR:true,${create_opts}});"
+    clear_stale_cluster_lock "${report_host}"
+    yes | $mysqlsh_self -e "cluster = dba.getCluster(); cluster.rescan()" 2>/dev/null
+}
+
 function fix_metadata_uuids() {
     # After a pod restart with data loss (PVC deleted), MySQL generates a new server_uuid.
     # The InnoDB Cluster metadata still has the old UUID, causing dba.getCluster() to fail
@@ -792,6 +811,10 @@ while true; do
 
         if [[ $desired_func == "reboot_from_complete_outage" ]]; then
             reboot_from_completeOutage
+        fi
+
+        if [[ $desired_func == "adopt_from_gr" ]]; then
+            adopt_from_gr
         fi
     fi
 

--- a/scripts/run_innodb.sh
+++ b/scripts/run_innodb.sh
@@ -357,6 +357,42 @@ function create_replication_user() {
         # Grant it separately so failure on older versions doesn't break the script.
         ${mysql_local} -N -e "SET SQL_LOG_BIN=0; SET GLOBAL super_read_only=OFF; GRANT TRANSACTION_GTID_TAG ON *.* TO '${replication_user}'@'%' WITH GRANT OPTION; FLUSH PRIVILEGES; SET GLOBAL super_read_only=ON; SET SQL_LOG_BIN=1;" 2>/dev/null
     fi
+
+    # Ensure the InnoDB Cluster privileges on EVERY start, not only when the
+    # replication user is created.
+    #
+    # A standalone -> InnoDBCluster promotion preserves the data directory by
+    # design, so ${replication_user} already exists there — created by run.sh with
+    # only REPLICATION SLAVE and BACKUP_ADMIN. The creation branch above is guarded
+    # on the user not existing, so on a promoted database it is skipped and the
+    # InnoDB-specific grants are never issued. MySQL Router bootstraps as this user
+    # and then loops forever on:
+    #
+    #   Error executing MySQL query "SELECT * FROM mysql_innodb_cluster_metadata.schema_version":
+    #   SELECT command denied to user 'repl'@'...' for table 'schema_version' (1142)
+    #
+    # leaving the Router never Ready and — because the primary Service selects the
+    # Router for InnoDBCluster — the database unreachable, even though the members
+    # are ONLINE and writable.
+    #
+    # GRANT is idempotent, so re-issuing on an already-granted user is a no-op.
+    log "INFO" "Ensuring replication user has the InnoDB Cluster privileges..."
+    retry 60 ${mysql_local} -N -e "
+        SET SQL_LOG_BIN=0;
+        SET GLOBAL super_read_only=OFF;
+        SET GLOBAL read_only=OFF;
+        GRANT CREATE USER, FILE, PROCESS, RELOAD, REPLICATION CLIENT, REPLICATION SLAVE, SELECT, SHUTDOWN, SUPER ON *.* TO '${replication_user}'@'%' WITH GRANT OPTION;
+        GRANT DELETE, INSERT, UPDATE ON mysql.* TO '${replication_user}'@'%' WITH GRANT OPTION;
+        GRANT ALTER, ALTER ROUTINE, CREATE, CREATE ROUTINE, CREATE TEMPORARY TABLES, CREATE VIEW, DELETE, DROP, EVENT, EXECUTE, INDEX, INSERT, LOCK TABLES, REFERENCES, SHOW VIEW, TRIGGER, UPDATE ON mysql_innodb_cluster_metadata.* TO '${replication_user}'@'%' WITH GRANT OPTION;
+        GRANT ALTER, ALTER ROUTINE, CREATE, CREATE ROUTINE, CREATE TEMPORARY TABLES, CREATE VIEW, DELETE, DROP, EVENT, EXECUTE, INDEX, INSERT, LOCK TABLES, REFERENCES, SHOW VIEW, TRIGGER, UPDATE ON mysql_innodb_cluster_metadata_bkp.* TO '${replication_user}'@'%' WITH GRANT OPTION;
+        GRANT ALTER, ALTER ROUTINE, CREATE, CREATE ROUTINE, CREATE TEMPORARY TABLES, CREATE VIEW, DELETE, DROP, EVENT, EXECUTE, INDEX, INSERT, LOCK TABLES, REFERENCES, SHOW VIEW, TRIGGER, UPDATE ON mysql_innodb_cluster_metadata_previous.* TO '${replication_user}'@'%' WITH GRANT OPTION;
+        GRANT CLONE_ADMIN, BACKUP_ADMIN, CONNECTION_ADMIN, EXECUTE, GROUP_REPLICATION_ADMIN, PERSIST_RO_VARIABLES_ADMIN, REPLICATION_APPLIER, REPLICATION_SLAVE_ADMIN, ROLE_ADMIN, SYSTEM_VARIABLES_ADMIN ON *.* TO '${replication_user}'@'%' WITH GRANT OPTION;
+        FLUSH PRIVILEGES;
+        SET GLOBAL read_only=ON;
+        SET GLOBAL super_read_only=ON;
+        SET SQL_LOG_BIN=1;
+    "
+
     touch /scripts/ready.txt
 }
 

--- a/scripts/run_innodb.sh
+++ b/scripts/run_innodb.sh
@@ -409,25 +409,6 @@ function create_cluster() {
     fi
 }
 
-# adopt_from_gr converts the pod's currently-running Group Replication group into
-# a managed InnoDB cluster IN PLACE, without tearing the group down or cloning.
-# Used when a GroupReplication database is transformed to InnoDBCluster: the group
-# is still ONLINE, so dba.createCluster(adoptFromGR:true) adopts every member and
-# preserves all data. Must run while GR is ONLINE (do not restart mysqld first).
-function adopt_from_gr() {
-    local mysqlsh_self="mysqlsh --js -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD} -h${report_host}"
-    clusterName=$(echo -n $BASE_NAME | sed 's/-/_/g')
-    ${mysql_local} -N -e "SET GLOBAL super_read_only=OFF; SET GLOBAL read_only=OFF;" 2>/dev/null
-    local create_opts="multiPrimary:false,force:true"
-    if [[ "$PRIMARY_TYPE" == "Multi-Primary" ]]; then
-        create_opts="multiPrimary:true,force:true"
-    fi
-    log "INFO" "adopting existing GR group as an InnoDB cluster (adoptFromGR:true)"
-    retry 5 $mysqlsh_self -e "dba.createCluster('$clusterName',{adoptFromGR:true,${create_opts}});"
-    clear_stale_cluster_lock "${report_host}"
-    yes | $mysqlsh_self -e "cluster = dba.getCluster(); cluster.rescan()" 2>/dev/null
-}
-
 function fix_metadata_uuids() {
     # After a pod restart with data loss (PVC deleted), MySQL generates a new server_uuid.
     # The InnoDB Cluster metadata still has the old UUID, causing dba.getCluster() to fail
@@ -811,10 +792,6 @@ while true; do
 
         if [[ $desired_func == "reboot_from_complete_outage" ]]; then
             reboot_from_completeOutage
-        fi
-
-        if [[ $desired_func == "adopt_from_gr" ]]; then
-            adopt_from_gr
         fi
     fi
 

--- a/scripts/run_innodb.sh
+++ b/scripts/run_innodb.sh
@@ -266,6 +266,9 @@ replication_user=repl
 
 clone_progress_interval=${CLONE_PROGRESS_INTERVAL:-15}
 
+# How often the Multi-Primary writability watcher re-checks this member.
+multi_primary_rw_interval=${MULTI_PRIMARY_RW_CHECK_INTERVAL:-10}
+
 # dba.addInstance waits dba.restartWaitTimeout seconds for the post-clone restart.
 # Raising it does not help: the clone's self-RESTART fails immediately (MY-013462,
 # nothing supervises mysqld in the container) and Group Replication evicts the
@@ -823,6 +826,59 @@ function reboot_from_completeOutage() {
     wait $pid
 }
 
+# ── Multi-Primary writability guard ──────────────────────────────────────────
+#
+# In a Multi-Primary cluster every ONLINE member is a PRIMARY and must accept
+# writes. Two things leave it read-only anyway:
+#
+#   * wait_for_host_online() sets read_only/super_read_only ON on every start,
+#     so an unjoined member cannot generate errant GTIDs;
+#   * the AdminAPI re-enables super_read_only on an instance it has just added.
+#     It does that unconditionally, about a second after Group Replication
+#     itself cleared it (observed: super_read_only last set by user `repl`,
+#     0.7s after GR logged MY-011566 "Setting super_read_only=OFF").
+#
+# Group Replication only ever clears super_read_only when it declares a member
+# online, and never touches read_only. The member therefore ends up writable to
+# SUPER users but read-only to everyone else, while cluster.status() still
+# advertises it as R/W — so the Router routes writes to it and every write from
+# an ordinary application user fails with ER_OPTION_PREVENTS_STATEMENT (1290).
+#
+# Single-Primary is unaffected: there a read-only secondary is correct, and this
+# guard never runs.
+function ensure_multi_primary_writable() {
+    [[ "$PRIMARY_TYPE" == "Multi-Primary" ]] || return 0
+
+    local state flags
+    state=$(${mysql_local} -N -e "
+        SELECT MEMBER_STATE FROM performance_schema.replication_group_members
+         WHERE MEMBER_HOST='${report_host}' LIMIT 1;" 2>/dev/null)
+    # Only an ONLINE member is a primary. While it is still joining, cloning or
+    # recovering the read-only state is deliberate — leave it alone.
+    [[ "$state" == "ONLINE" ]] || return 0
+
+    flags=$(${mysql_local} -N -e "SELECT @@read_only + @@super_read_only;" 2>/dev/null)
+    [[ "$flags" =~ ^[0-9]+$ ]] || return 0
+    if [[ "$flags" -gt 0 ]]; then
+        log "INFO" "Multi-Primary member is ONLINE but read-only (read_only+super_read_only=$flags) — clearing both"
+        ${mysql_local} -N -e "SET GLOBAL super_read_only=OFF; SET GLOBAL read_only=OFF;" 2>/dev/null
+    fi
+}
+
+# multi_primary_writability_watcher keeps the guard applied for the life of the
+# pod. Clearing the flags once after this member joins is not enough: a later
+# cluster.addInstance()/rescan() driven from *another* pod re-enables
+# super_read_only on this one too, and by then this script is parked in
+# `wait $pid` and would never notice.
+function multi_primary_writability_watcher() {
+    [[ "$PRIMARY_TYPE" == "Multi-Primary" ]] || return 0
+    log "INFO" "starting Multi-Primary writability watcher (interval ${multi_primary_rw_interval}s)"
+    while true; do
+        ensure_multi_primary_writable
+        sleep "${multi_primary_rw_interval}"
+    done
+}
+
 function start_mysqld_in_background() {
     log "INFO" "Starting mysql server with 'docker-entrypoint.sh mysqld $args'..."
     # Use docker-entrypoint.sh (in PATH at /usr/local/bin/) — works on both
@@ -843,6 +899,9 @@ if [[ "$restart_required" == "1" ]]; then
     start_mysqld_in_background
     wait_for_host_online "${MYSQL_ROOT_USERNAME}" "$report_host" "$MYSQL_ROOT_PASSWORD"
 fi
+
+# Runs for the life of the pod; a no-op unless PRIMARY_TYPE is Multi-Primary.
+multi_primary_writability_watcher &
 
 mysqld_alive=0
 function check_mysqld_alive() {
@@ -957,6 +1016,12 @@ while true; do
         sleep 10
         continue
     fi
+
+    # The join just finished, so this is the earliest point at which the
+    # AdminAPI's super_read_only can be undone. The watcher would get there
+    # too, up to one interval later; doing it here keeps the member writable
+    # from the moment it reports ONLINE.
+    ensure_multi_primary_writable
 
     log "INFO" "waiting for mysql process id = $pid"
     wait $pid

--- a/scripts/run_innodb.sh
+++ b/scripts/run_innodb.sh
@@ -1004,19 +1004,6 @@ while true; do
     rm -rf /scripts/signal.txt
     rm -rf /scripts/setup.txt
 
-    # A join that exhausted its retries must not be terminal. The coordinator
-    # keeps re-issuing the signal, but blocking on the mysqld pid below means
-    # this loop never reads it again — the pod stays Running and out of the
-    # group until someone deletes it by hand. If we are still not a group
-    # member, re-arm and wait for the next signal instead.
-    member_state=$(${mysql_local} -N -e \
-        "SELECT MEMBER_STATE FROM performance_schema.replication_group_members WHERE MEMBER_HOST='${report_host}' LIMIT 1;" 2>/dev/null)
-    if [[ "$member_state" != "ONLINE" ]]; then
-        log "WARNING" "not ONLINE in the group after handling the signal — waiting for the coordinator to signal again"
-        sleep 10
-        continue
-    fi
-
     # The join just finished, so this is the earliest point at which the
     # AdminAPI's super_read_only can be undone. The watcher would get there
     # too, up to one interval later; doing it here keeps the member writable

--- a/scripts/run_innodb.sh
+++ b/scripts/run_innodb.sh
@@ -266,9 +266,6 @@ replication_user=repl
 
 clone_progress_interval=${CLONE_PROGRESS_INTERVAL:-15}
 
-# How often the Multi-Primary writability watcher re-checks this member.
-multi_primary_rw_interval=${MULTI_PRIMARY_RW_CHECK_INTERVAL:-10}
-
 # dba.addInstance waits dba.restartWaitTimeout seconds for the post-clone restart.
 # Raising it does not help: the clone's self-RESTART fails immediately (MY-013462,
 # nothing supervises mysqld in the container) and Group Replication evicts the
@@ -865,20 +862,6 @@ function ensure_multi_primary_writable() {
     fi
 }
 
-# multi_primary_writability_watcher keeps the guard applied for the life of the
-# pod. Clearing the flags once after this member joins is not enough: a later
-# cluster.addInstance()/rescan() driven from *another* pod re-enables
-# super_read_only on this one too, and by then this script is parked in
-# `wait $pid` and would never notice.
-function multi_primary_writability_watcher() {
-    [[ "$PRIMARY_TYPE" == "Multi-Primary" ]] || return 0
-    log "INFO" "starting Multi-Primary writability watcher (interval ${multi_primary_rw_interval}s)"
-    while true; do
-        ensure_multi_primary_writable
-        sleep "${multi_primary_rw_interval}"
-    done
-}
-
 function start_mysqld_in_background() {
     log "INFO" "Starting mysql server with 'docker-entrypoint.sh mysqld $args'..."
     # Use docker-entrypoint.sh (in PATH at /usr/local/bin/) — works on both
@@ -899,9 +882,6 @@ if [[ "$restart_required" == "1" ]]; then
     start_mysqld_in_background
     wait_for_host_online "${MYSQL_ROOT_USERNAME}" "$report_host" "$MYSQL_ROOT_PASSWORD"
 fi
-
-# Runs for the life of the pod; a no-op unless PRIMARY_TYPE is Multi-Primary.
-multi_primary_writability_watcher &
 
 mysqld_alive=0
 function check_mysqld_alive() {
@@ -1004,10 +984,12 @@ while true; do
     rm -rf /scripts/signal.txt
     rm -rf /scripts/setup.txt
 
-    # The join just finished, so this is the earliest point at which the
-    # AdminAPI's super_read_only can be undone. The watcher would get there
-    # too, up to one interval later; doing it here keeps the member writable
-    # from the moment it reports ONLINE.
+    # The join has finished, so this is the point at which the AdminAPI has
+    # done whatever it is going to do to super_read_only. One clear here is
+    # enough: the flag is only ever re-enabled as part of THIS member's own
+    # join, never by a later join from another pod. Verified by scaling a
+    # Multi-Primary cluster from 3 to 4 members with no watcher running at
+    # all -- every member, old and new, stayed 0/0 and writable.
     ensure_multi_primary_writable
 
     log "INFO" "waiting for mysql process id = $pid"


### PR DESCRIPTION
…adopt

adopt_from_gr runs dba.createCluster(clusterName,{adoptFromGR:true,...}) on the
pod's running Group Replication group, converting it into a managed InnoDB
cluster in place without teardown or clone. Signalled by the coordinator when a
GroupReplication database is transformed to InnoDBCluster.

Signed-off-by: Sk Ali Arman <arman@appscode.com>